### PR TITLE
Fix bug with multi-line list items

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "md-fixup"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "atty",
  "clap",

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -4349,7 +4349,11 @@ fn process_file(
 
             if !output.is_empty() && !output[output.len() - 1].trim().is_empty() {
                 let prev = output[output.len() - 1].trim();
-                if prev.starts_with("```") || is_list_item(&output[output.len() - 1]) {
+                let is_list_continuation =
+                    line_indent > 0 && is_list_item(&output[output.len() - 1]);
+                if !is_list_continuation
+                    && (prev.starts_with("```") || is_list_item(&output[output.len() - 1]))
+                {
                     output.push("\n".to_string());
                     changes_made = true;
                 }
@@ -5352,6 +5356,19 @@ mod tests {
         assert!(
             output.contains("\t- item 3\n\t- item 4\n"),
             "Output:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_multi_line_list_items_fixture_length_preserved() {
+        let input = include_str!("../../tests/fixtures/multi-line-list-items.md");
+        let output = process_test_content(input);
+        assert_eq!(
+            output.len(),
+            input.len(),
+            "Output length differs from input length.\nInput:\n{}\nOutput:\n{}",
+            input,
             output
         );
     }

--- a/tests/fixtures/multi-line-list-items.md
+++ b/tests/fixtures/multi-line-list-items.md
@@ -1,0 +1,6 @@
+Here is a list
+
+* this is a long-ish list item that needs to be longer than
+  sixty chars followed by another one
+* this is a list item
+


### PR DESCRIPTION
I noticed the following unwanted behavior where an extra line is inserted into a multi-line list item.

This is my first time doing any rust. The test and solution are vibe coded with Opus 4.7.

Here is a shell session showing the bug:

```
$ cat -p tests/fixtures/multi-line-list-items.md                       
Here is a list
 
* this is a long-ish list item that needs to be longer than
  sixty chars followed by another one
* this is a list item

$ rust/target/release/md-fixup tests/fixtures/multi-line-list-items.md 
Here is a list

* this is a long-ish list item that needs to be longer than

  sixty chars followed by another one
* this is a list item
```