### PR TITLE
fix(rust): normalize setext headings to ATX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive markdown linter and formatter that normalizes formatting and wra
 
 ## Features
 
-md-fixup performs 33 different normalization and formatting rules:
+md-fixup performs 34 different normalization and formatting rules:
 
 1. Normalizes line endings to Unix
 2. Trims trailing whitespace (preserves exactly 2 spaces for line breaks)
@@ -41,6 +41,7 @@ md-fixup performs 33 different normalization and formatting rules:
 31. Normalizes Liquid tag spacing (`{%tag%}` -> `{% tag %}`)
 32. Normalizes blockquote marker chains (removes spaces between leading `>` markers, e.g. `> >` -> `>>`)
 33. Compresses list spacing by removing unnecessary blank lines between list items (bulleted and numbered)
+34. Normalizes setext headings (`===` / `---`) to ATX headings (`#` / `##`)
 
 **Definition lists:** md-fixup compresses definition lists by removing blank lines before and between consecutive definition items (`:\s+`). This also works inside blockquotes (removing quote-only blank lines like `>` between definition items). This behavior is part of rule `3` (`blank-lines`).
 
@@ -156,6 +157,7 @@ Rules can be skipped using either their number or keyword:
 - `31` / `liquid-tags` - Normalize Liquid tag spacing
 - `32` / `blockquote-markers` - Normalize blockquote marker chains (remove spaces between `>` markers)
 - `33` / `compress-lists` - Compress list spacing by removing unnecessary blank lines between list items
+- `34` / `setext-to-atx` - Normalize setext headings (`===` / `---`) to ATX headings (`#` / `##`)
 
 Group keywords (expand to multiple rules):
 
@@ -190,6 +192,7 @@ rules:
   include:
     - line-endings
     - blank-lines
+    - setext-to-atx
 ```
 
 Or to skip specific rules:
@@ -202,6 +205,7 @@ rules:
     - line-endings
     - blank-lines
     - wrap
+    - setext-to-atx
 ```
 
 **Configuration merging:**

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -908,6 +908,30 @@ fn is_headline(line: &str) -> bool {
         || Regex::new(r"^#+[^\s#]").unwrap().is_match(stripped)
 }
 
+fn is_setext_heading(line: &str) -> bool {
+    let stripped = line.trim();
+    Regex::new(r"^(={2,}|-{2,})\s*$").unwrap().is_match(stripped)
+}
+
+fn normalize_setext_to_atx_headings(heading_line: &str, underline_line: &str) -> Option<String> {
+    if !is_setext_heading(underline_line) {
+        return None;
+    }
+
+    let heading_text = heading_line.trim();
+    if heading_text.is_empty() {
+        return None;
+    }
+
+    let level = if underline_line.trim_start().starts_with('=') {
+        1
+    } else {
+        2
+    };
+
+    Some(format!("{} {}\n", "#".repeat(level), heading_text))
+}
+
 fn is_horizontal_rule(line: &str) -> bool {
     let stripped = line.trim();
     Regex::new(r"^[-*_]{3,}$").unwrap().is_match(stripped)
@@ -3018,6 +3042,7 @@ const LINTING_RULES: &[LintingRule] = &[
     LintingRule { num: 31, description: "Normalize Liquid tag spacing", keyword: "liquid-tags" },
     LintingRule { num: 32, description: "Normalize blockquote marker chains (remove spaces between > markers)", keyword: "blockquote-markers" },
     LintingRule { num: 33, description: "Compress list item spacing (remove unnecessary blank lines between items)", keyword: "compress-lists" },
+    LintingRule { num: 34, description: "Normalize setext headings to ATX headings", keyword: "setext-to-atx" },
 ];
 
 fn parse_skip_rules(skip_str: &str) -> Result<(HashSet<u8>, bool, bool), String> {
@@ -3180,6 +3205,9 @@ fn init_config_file(force: bool, local: bool) -> Option<PathBuf> {
     for rule in all_rules {
         yaml_content.push_str(&format!("    - {}\n", rule));
     }
+    yaml_content.push_str(
+        "  # To disable setext heading conversion, move to skip:\n  # skip:\n  #   - setext-to-atx\n",
+    );
 
     fs::write(&config_file, yaml_content).ok()?;
     Some(config_file)
@@ -3953,6 +3981,43 @@ fn process_file(
                     output.extend(normalized_table);
                     i = j;
                     consecutive_blank_lines = 0;
+                    continue;
+                }
+            }
+        }
+
+        // Convert setext headings to ATX headings to avoid ambiguity with horizontal rules.
+        if !skip_rules.contains(&34) && i + 1 < lines.len() {
+            if is_setext_heading(&lines[i + 1])
+                && !is_headline(&line)
+                && !is_horizontal_rule(&line)
+                && !is_code_block(&line)
+                && !is_list_item(&line)
+                && !is_blockquote(&line)
+            {
+                if let Some(normalized_heading) =
+                    normalize_setext_to_atx_headings(&line, &lines[i + 1])
+                {
+                    // Clear list context when encountering a heading (non-list element)
+                    list_context_stack.clear();
+                    current_list_indent_unit = None;
+
+                    output.push(normalized_heading);
+                    changes_made = true;
+
+                    if !skip_rules.contains(&5) && i + 2 < lines.len() {
+                        let next_line = &lines[i + 2];
+                        if !next_line.trim().is_empty()
+                            && !is_headline(next_line)
+                            && !is_code_block(next_line)
+                        {
+                            output.push("\n".to_string());
+                            changes_made = true;
+                        }
+                    }
+
+                    consecutive_blank_lines = 0;
+                    i += 2;
                     continue;
                 }
             }
@@ -5181,6 +5246,42 @@ mod tests {
         assert!(!is_list_item("*This"));
         assert!(!is_list_item("Not a list"));
         assert!(!is_list_item(""));
+    }
+
+    #[test]
+    fn test_setext_h1_converts_to_atx() {
+        let input = "Heading one\n====\nParagraph text.\n";
+        let output = process_test_content(input);
+        assert!(output.contains("# Heading one\n\nParagraph text.\n"), "Output:\n{}", output);
+        assert!(!output.contains("\n====\n"), "Output:\n{}", output);
+    }
+
+    #[test]
+    fn test_setext_h2_converts_to_atx_even_with_three_dashes() {
+        let input = "Heading two\n---\nParagraph text.\n";
+        let output = process_test_content(input);
+        assert!(output.contains("## Heading two\n\nParagraph text.\n"), "Output:\n{}", output);
+        assert!(!output.contains("\n---\nParagraph"), "Output:\n{}", output);
+    }
+
+    #[test]
+    fn test_horizontal_rule_without_setext_context_is_preserved() {
+        let input = "---\nParagraph text.\n";
+        let output = process_test_content(input);
+        assert!(output.contains("---\n\nParagraph text.\n"), "Output:\n{}", output);
+        assert!(!output.contains("## "), "Output:\n{}", output);
+    }
+
+    #[test]
+    fn test_setext_to_atx_can_be_disabled_with_rule_34() {
+        let input = "Heading two\n---\nParagraph text.\n";
+        let mut skip_rules = HashSet::new();
+        skip_rules.insert(30); // Rule 30 (inline-links) is disabled by default in tests
+        skip_rules.insert(34); // Disable setext -> ATX normalization
+        let output = process_test_content_with_skip(input, &skip_rules);
+        assert!(!output.contains("## Heading two"), "Output:\n{}", output);
+        assert!(output.contains("Heading two"), "Output:\n{}", output);
+        assert!(output.contains("---"), "Output:\n{}", output);
     }
 
     #[test]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3205,9 +3205,6 @@ fn init_config_file(force: bool, local: bool) -> Option<PathBuf> {
     for rule in all_rules {
         yaml_content.push_str(&format!("    - {}\n", rule));
     }
-    yaml_content.push_str(
-        "  # To disable setext heading conversion, move to skip:\n  # skip:\n  #   - setext-to-atx\n",
-    );
 
     fs::write(&config_file, yaml_content).ok()?;
     Some(config_file)


### PR DESCRIPTION
Potentially addresses issue #5 

**New normalization rule for setext headings:**

- Added rule 34 (not that one): "Normalize setext headings to ATX headings" (converts headings using `===`/`---` underlines to `#`/`##` ATX style). This is reflected in the rule list, configuration documentation, and sample config generation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208) [[6]](diffhunk://#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8R3045) [[7]](diffhunk://#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8R3208-R3210)

**Implementation in code:**

- Introduced `is_setext_heading` and `normalize_setext_to_atx_headings` functions to detect and convert setext headings during file processing. The conversion logic is integrated into the main processing loop, respecting skip rules. [[1]](diffhunk://#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8R911-R934) [[2]](diffhunk://#diff-6830e545eaa10c62f07d60f7b6339ab85b95c03bf93ee5123e912a54fe09cdc8R3989-R4025)

**Testing:**

- Added comprehensive tests to ensure setext headings are converted correctly, that horizontal rules are not misinterpreted, and that the rule can be disabled via configuration.

**Trade-offs:**
- We intentionally normalize all setext headings to ATX in output. This is a formatting choice that reduces parser ambiguity and yields more predictable downstream rule application, at the cost of not preserving original setext style.
- Detection is conservative (skips list items, blockquotes, existing headlines, code fences, and blank lines) to avoid broad behavioral changes.

# This pull request was aided by Copilot AI but hand-checked. 